### PR TITLE
Небольшие изменения в системе сервисных ответов

### DIFF
--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jpa/controllers/UserController.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jpa/controllers/UserController.java
@@ -4,8 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import tech.vinc3nzo.prognet.jpa.models.User;
 import tech.vinc3nzo.prognet.jpa.repositories.UserRepository;
+import tech.vinc3nzo.prognet.models.CommonResponseObject;
+import tech.vinc3nzo.prognet.models.util.ResultCode;
 
 import java.util.List;
 
@@ -16,7 +17,12 @@ public class UserController {
     private UserRepository userRepository;
 
     @GetMapping("/users")
-    public ResponseEntity<List<User>> all() {
-        return ResponseEntity.ok(userRepository.findAll());
+    public ResponseEntity<CommonResponseObject> all() {
+        return ResponseEntity.ok(
+                new CommonResponseObject(
+                        userRepository.findAll(),
+                        List.of(),
+                        List.of(),
+                        ResultCode.SUCCESS));
     }
 }

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jwtutils/controllers/JwtController.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jwtutils/controllers/JwtController.java
@@ -1,12 +1,19 @@
 package tech.vinc3nzo.prognet.jwtutils.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import tech.vinc3nzo.prognet.jwtutils.*;
 import tech.vinc3nzo.prognet.jwtutils.models.*;
+import tech.vinc3nzo.prognet.models.CommonResponseObject;
+import tech.vinc3nzo.prognet.models.EmptyObject;
+import tech.vinc3nzo.prognet.models.FieldErrorObject;
+import tech.vinc3nzo.prognet.models.util.ResultCode;
+
+import java.util.List;
 
 @RestController
 @CrossOrigin
@@ -20,9 +27,28 @@ public class JwtController {
     private TokenManager tokenManager;
 
     @PostMapping("/auth/login")
-    public ResponseEntity<JwtResponseModel> createToken(@RequestBody JwtRequestModel request)
+    public ResponseEntity<CommonResponseObject> createToken(@RequestBody JwtRequestModel request)
             throws Exception
     {
+        if (request.getUsername() == null) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new CommonResponseObject(
+                            new EmptyObject(),
+                            List.of("The username field is invalid"),
+                            List.of(new FieldErrorObject("username", "The username field is invalid")),
+                            ResultCode.REQUEST_FAILED));
+        }
+        if (request.getPassword() == null) {
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(new CommonResponseObject(
+                            new EmptyObject(),
+                            List.of("The password field is invalid"),
+                            List.of(new FieldErrorObject("password", "The password field is invalid")),
+                            ResultCode.REQUEST_FAILED));
+        }
+
         try {
             authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(
@@ -30,15 +56,22 @@ public class JwtController {
                             request.getPassword())
             );
         }
-        catch (DisabledException e) {
-            throw new Exception("the user is disabled", e);
-        }
         catch (BadCredentialsException e) {
-            throw new Exception("the credentials are invalid", e);
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .body(new CommonResponseObject(
+                            null,
+                            List.of("The credentials are invalid"),
+                            List.of(),
+                            ResultCode.AUTH_REJECTED));
         }
 
         UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUsername());
         String jwtToken = tokenManager.generateJwtToken(userDetails);
-        return ResponseEntity.ok(new JwtResponseModel(jwtToken));
+        return ResponseEntity.ok(new CommonResponseObject(
+                new JwtResponseModel(jwtToken),
+                List.of(),
+                List.of(),
+                ResultCode.SUCCESS));
     }
 }

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jwtutils/models/JwtResponseModel.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/jwtutils/models/JwtResponseModel.java
@@ -1,5 +1,8 @@
 package tech.vinc3nzo.prognet.jwtutils.models;
 
+/**
+ * The model representing a form of service's response.
+ */
 public class JwtResponseModel {
     private final String token;
 

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/CommonResponseObject.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/CommonResponseObject.java
@@ -1,0 +1,65 @@
+package tech.vinc3nzo.prognet.models;
+
+import java.util.List;
+
+/**
+ * A compatibility layer object between the
+ * old API and the new one.
+ */
+public class CommonResponseObject {
+    private Object data;
+    private List<String> messages;
+    private List<FieldErrorObject> fieldsErrors;
+    private Integer resultCode;
+
+    protected CommonResponseObject() { }
+
+    public CommonResponseObject(Object data, List<String> messages, List<FieldErrorObject> fieldsErrors, Integer resultCode) {
+        this.data = data;
+        this.messages = messages;
+        this.fieldsErrors = fieldsErrors;
+        this.resultCode = resultCode;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<String> messages) {
+        this.messages = messages;
+    }
+
+    public List<FieldErrorObject> getFieldsErrors() {
+        return fieldsErrors;
+    }
+
+    public void setFieldsErrors(List<FieldErrorObject> fieldsErrors) {
+        this.fieldsErrors = fieldsErrors;
+    }
+
+    public Integer getResultCode() {
+        return resultCode;
+    }
+
+    public void setResultCode(Integer resultCode) {
+        this.resultCode = resultCode;
+    }
+
+    @Override
+    public String toString() {
+        return "ResponseObject[" +
+                "data=" + data +
+                ", messages=" + messages +
+                ", fieldsErrors=" + fieldsErrors +
+                ", resultCode=" + resultCode +
+                ']';
+    }
+}

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/EmptyObject.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/EmptyObject.java
@@ -1,0 +1,12 @@
+package tech.vinc3nzo.prognet.models;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * A placeholder object for returning when
+ * the "data" field in a CommonResponseObject
+ * is empty.
+ */
+@JsonSerialize
+public class EmptyObject {
+}

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/FieldErrorObject.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/FieldErrorObject.java
@@ -1,0 +1,40 @@
+package tech.vinc3nzo.prognet.models;
+
+/**
+ * A helper object for the ResponseObject.
+ */
+public class FieldErrorObject {
+    private String field;
+    private String error;
+
+    protected FieldErrorObject() { }
+
+    public FieldErrorObject(String field, String error) {
+        this.field = field;
+        this.error = error;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    @Override
+    public String toString() {
+        return "FieldErrorObject[" +
+                "field='" + field + '\'' +
+                ", error='" + error + '\'' +
+                ']';
+    }
+}

--- a/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/util/ResultCode.java
+++ b/backend/prognet/src/main/java/tech/vinc3nzo/prognet/models/util/ResultCode.java
@@ -1,0 +1,27 @@
+package tech.vinc3nzo.prognet.models.util;
+
+public class ResultCode {
+    /**
+     * This code simply means that the request
+     * has successfully been processed in the service.
+     */
+    public static final int SUCCESS = 0;
+
+    /**
+     * This code means that the request failed due
+     * to unspecified internal service error.
+     */
+    public static final int INTERNAL_ERROR = 1;
+
+    /**
+     * This code means that the request is malformed,
+     * e.g. some necessary fields are absent in it.
+     */
+    public static final int REQUEST_FAILED = 2;
+
+    /**
+     * The code to specify that the authentication request
+     * has been rejected due to errors in user credentials.
+     */
+    public static final int AUTH_REJECTED = 3;
+}


### PR DESCRIPTION
Теперь все данные, возвращаемые сервисом, будут обернуты в `CommonResponseObject`, представляющий из себя в JSON-формате следующий объект:
```json
{
    "data": { ... основные данные ... },
    "messages": [
        "...",
        "..."
    ],
    "fieldsErrors": [
        {
            "<field_name>": "<desc>"
        },
        ...
    ],
    "resultCode": <integer>
}
```